### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#Elo Rating PHP
+# Elo Rating PHP
 A PHP class which implements the [Elo rating system](http://en.wikipedia.org/wiki/Elo_rating_system).
 
-#Usage
+# Usage
 
     require 'src/Rating/Rating.php';
 
@@ -26,6 +26,6 @@ A PHP class which implements the [Elo rating system](http://en.wikipedia.org/wik
     
 ---------------------------------------
 
-#Credits
+# Credits
     
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">Elo Rating PHP</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://michalchovanec.com" property="cc:attributionName" rel="cc:attributionURL">Michal Chovanec</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
