### PR TITLE
makes psr-4 autoload compatible with Rating class namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Chovanec\\Rating\\": "src/"
+      "Chovanec\\": "src/"
     }
   },
   "minimum-stability": "stable"


### PR DESCRIPTION
class `Rating` in file `src/Rating/Rating.php` has namespace `Chovanec/Rating`

composer.json assumes that all files from `src` are loaded into `Chovanec/Rating` namespace, so there are two possibilities:
1. class `Rating` in file `src/Rating/Rating.php` should use namespace `Chovanec/Rating/Rating`
2. psr-4 in composer.json should map `src` directory to `Chovanec` only

i've choosen second option, because in first option, including `Rating` class would be like `use Chovanec\Rating\Rating\Rating` what looks quite strange